### PR TITLE
inverts discount amount (should be positive); adds promo_total inside…

### DIFF
--- a/app/models/spree/calculator/taxjar_calculator.rb
+++ b/app/models/spree/calculator/taxjar_calculator.rb
@@ -15,7 +15,6 @@ module Spree
     end
 
     def compute_line_item(item)
-      logger.debug line_item: {order: {id: item.order.id, number: item.order.number}}
       if rate.included_in_price
         0
       else
@@ -24,7 +23,6 @@ module Spree
     end
 
     def compute_shipment(shipment)
-      logger.debug shipment: {order: {id: shipment.order.id, number: shipment.order.number}}
       tax_for_shipment(shipment)
     end
 
@@ -36,70 +34,76 @@ module Spree
       end
     end
 
-    private
-      def rate
-        calculable
+   private
+
+    def rate
+      calculable
+    end
+
+    def tax_for_shipment(shipment)
+      order = shipment.order
+      return 0 unless tax_address = order.tax_address
+
+      rails_cache_key = cache_key(order, shipment, tax_address)
+      logger.debug "[Taxjar] tax_for_shipment: #{shipment.inspect}"
+      Rails.cache.fetch(rails_cache_key, expires_in: CACHE_EXPIRATION_DURATION) do
+        Spree::Taxjar.new(preferred_api_key, order, nil, shipment).calculate_tax_for_shipment
+      end
+    end
+
+    def tax_for_item(item)
+      order = item.order
+      return 0 unless tax_address = order.tax_address
+
+      rails_cache_key = cache_key(order, item, tax_address)
+
+      logger.debug "[Taxjar] tax_for_item order #{item.order.number}: lineitem #{item.id}, $#{item.amount.to_f}, promo: $#{item.promo_total}"
+      if SpreeTaxjar.extra_debugging && (read_key = Rails.cache.read(rails_cache_key))
+        logger.debug "[Taxjar] ... using cached response; cache key is #{rails_cache_key}; value =#{read_key}"
+
       end
 
-      def tax_for_shipment(shipment)
-        order = shipment.order
-        return 0 unless tax_address = order.tax_address
+      ## Test when caching enabled that only 1 API call is sent for an order
+      ## should avoid N calls for N line_items
+      Rails.cache.fetch(rails_cache_key, expires_in: CACHE_EXPIRATION_DURATION) do
+        taxjar_response = Spree::Taxjar.new(preferred_api_key, order, nil, nil, item).calculate_tax_for_order
+        return 0 unless taxjar_response
 
-        rails_cache_key = cache_key(order, shipment, tax_address)
+        tax_for_current_item = cache_response(taxjar_response, order, tax_address, item)
+        tax_for_current_item
+      end
+    end
 
-        logger.debug shipment: {order: {id: shipment.order.id, number: shipment.order.number}}, cache_key: rails_cache_key
-
-        Rails.cache.fetch(rails_cache_key, expires_in: CACHE_EXPIRATION_DURATION) do
-          Spree::Taxjar.new(preferred_api_key, order, nil, shipment).calculate_tax_for_shipment
+    def cache_response(taxjar_response, order, address, item = nil)
+      ## res is set to faciliate testing as to return computed result from API
+      ## for given line_item
+      ## better to use Rails.cache.fetch for order and wrapping lookup based on line_item id
+      res = nil
+      taxjar_response.breakdown.line_items.each do |line_item|
+        if !item
+          item = Spree::LineItem.find(line_item.id)
         end
+        res = line_item.tax_collectable
+
+        this_item_cache_key = cache_key(order, item, address)
+        logger.debug "[Taxjar] ... writing to taxjar cache cache_key is #{this_item_cache_key}; amount=#{line_item.tax_collectable}"
+
+        Rails.cache.write(this_item_cache_key, line_item.tax_collectable, expires_in: CACHE_EXPIRATION_DURATION)
       end
+      res
+    end
 
-      def tax_for_item(item)
-        order = item.order
-        return 0 unless tax_address = order.tax_address
-
-        rails_cache_key = cache_key(order, item, tax_address)
-
-        logger.debug line_item: {order: {id: item.order.id, number: item.order.number}}, cache_key: rails_cache_key
-
-        ## Test when caching enabled that only 1 API call is sent for an order
-        ## should avoid N calls for N line_items
-        Rails.cache.fetch(rails_cache_key, expires_in: CACHE_EXPIRATION_DURATION) do
-          taxjar_response = Spree::Taxjar.new(preferred_api_key, order).calculate_tax_for_order
-          return 0 unless taxjar_response
-          tax_for_current_item = cache_response(taxjar_response, order, tax_address, item)
-          tax_for_current_item
-        end
+    def cache_key(order, item, address)
+      if item.is_a?(Spree::LineItem)
+        ['Taxjar-Spree::LineItem', order.id, item.id, address.state_id, address.zipcode, item.amount, item.promo_total, order.promo_total, :amount_to_collect]
+      elsif item.is_a?(Spree::Shipment)
+        ['Taxjar-Spree::Shipment', order.id, item.id, address.state_id, address.zipcode, item.cost, :amount_to_collect]
       end
+    end
 
-      def cache_response(taxjar_response, order, address, item = nil)
-        logger.debug order: {id: order.id, number: order.number}, taxjar_api_advanced_res: taxjar_response
-        logger.debug order: {id: order.id, number: order.number}, taxjar_api_advanced_res: taxjar_response.breakdown.line_items
-        ## res is set to faciliate testing as to return computed result from API
-        ## for given line_item
-        ## better to use Rails.cache.fetch for order and wrapping lookup based on line_item id
-        res = nil
-        taxjar_response.breakdown.line_items.each do |line_item|
-          item_from_db = Spree::LineItem.find_by(id: line_item.id)
-          if item && item_from_db.id == item.id
-            res = line_item.tax_collectable
-          end
-          Rails.cache.write(cache_key(order, item_from_db, address), line_item.tax_collectable, expires_in: CACHE_EXPIRATION_DURATION)
-        end
-        res
-      end
-
-      def cache_key(order, item, address)
-        if item.is_a?(Spree::LineItem)
-          ['Spree::LineItem', order.id, item.id, address.state_id, address.zipcode, item.amount, :amount_to_collect]
-        else
-          ['Spree::Shipment', order.id, item.id, address.state_id, address.zipcode, item.cost, :amount_to_collect]
-        end
-      end
-
-      # Imported from Spree::VatPriceCalculation
-      def round_to_two_places(amount)
-        BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
-      end
+    # Imported from Spree::VatPriceCalculation
+    def round_to_two_places(amount)
+      BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
+    end
   end
 end

--- a/app/models/spree/taxjar.rb
+++ b/app/models/spree/taxjar.rb
@@ -2,91 +2,111 @@ module Spree
   class Taxjar
     attr_reader :client, :order, :reimbursement, :shipment
 
-    def initialize(api_key, order = nil, reimbursement = nil, shipment = nil)
+    def initialize(api_key, order = nil, reimbursement = nil, shipment = nil, fresh_lineitem = nil)
+      # TODO: refactor into splat pattern to remove this arity dependancy
+
+      # if fresh_lineitem is passed prefer that over the association
+      # from the order, because the association from the order may be stale
       @order = order
       @shipment = shipment
       @reimbursement = reimbursement
+      @fresh_lineitem = fresh_lineitem # TODO: code smell, this is here because solidus is asking for a tax to be calcualted
+      # with stale data in the database
       @client = ::Taxjar::Client.new api_key: api_key
     end
 
     def create_refund_transaction_for_order
       if has_nexus? && !reimbursement_present?
         api_params = refund_params
-        Rails.logger.debug order: {id: @order.id, number: @order.number}, reimbursement: {id: @reimbursement.id, number: @reimbursement.number}, api_params: api_params
         api_response = @client.create_refund(api_params)
-        Rails.logger.debug order: {id: @order.id, number: @order.number}, reimbursement: {id: @reimbursement.id, number: @reimbursement.number}, api_response: api_response
         api_response
       end
     end
 
     def create_transaction_for_order
-      Rails.logger.debug order: {id: @order.id, number: @order.number}
       if has_nexus?
         api_params = transaction_parameters
-        Rails.logger.debug order: {id: @order.id, number: @order.number}, api_params: api_params
+        if (SpreeTaxjar.extra_debugging)
+          Rails.logger.debug "[Taxjar] create_transaction_for_order- for order #{@order.number}  api_params: #{ api_params.to_yaml}"
+        end
+
         api_response = @client.create_order(api_params)
-        Rails.logger.debug order: {id: @order.id, number: @order.number}, api_response: api_response
+        if (SpreeTaxjar.extra_debugging)
+
+          Rails.logger.debug "[Taxjar] create_transaction_for_order- for order #{@order.number}  api_response: #{ api_response.to_yaml}"
+        end
+
+
+        Rails.logger.debug "[Taxjar] create_transaction_for_order #{@order.number} api_response: #{api_response.inspect}"
         api_response
       end
     rescue HTTP::Error
-      Rails.logger.error "Taxjar Failure: Failed to create transaction for order #{@order.number}"
+      Rails.logger.error "[Taxjar] create_transaction_for_order-Failure: Failed to create transaction for order #{@order.number}"
       # Silently ignore
     end
 
     def delete_transaction_for_order
-      Rails.logger.debug order: {id: @order.id, number: @order.number}
       if has_nexus?
         api_response = @client.delete_order(@order.number)
-        Rails.logger.debug order: {id: @order.id, number: @order.number}, api_response: api_response
+        Rails.logger.debug "[Taxjar] delete_transaction_for_order #{order.number} api_response: #{api_response.inspect}"
         api_response
       end
     rescue ::Taxjar::Error::NotFound => e
-      Rails.logger.warn order: {id: @order.id, number: @order.number}, error_msg: e.message
+      Rails.logger.warn "[Taxjar] Taxjar::Error::NotFound: #{order.number} error_msg: #{e.message}"
     end
 
     def calculate_tax_for_shipment
-      Rails.logger.debug shipment: {order: {id: @shipment.order.id, number: @shipment.order.number}}
       if has_nexus?
         api_params = shipment_tax_params
-        Rails.logger.debug shipment: {order: {id: @shipment.order.id, number: @shipment.order.number}, api_params: api_params}
-        api_response = @client.tax_for_order(api_params)
-        Rails.logger.debug shipment: {order: {id: @shipment.order.id, number: @shipment.order.number}, api_response: api_response}
+        begin
+          api_response = @client.tax_for_order(api_params)
+        rescue Taxjar::Error => e
+          puts "[Taxjar] exception thrown calculate_tax_for_shipment - #{e.class.name}"
+          puts "[Taxjar] exception thrown calculate_tax_for_shipment- #{e.class.name}"
+          raise e if ! SpreeTaxjar.swallow_errors
+        end
         api_response.amount_to_collect
       else
         0
       end
     rescue HTTP::Error
-      Rails.logger.error "Taxjar Failure: Failed to calculate tax for shipment #{@shipment.id} (#{@shipment.order.number})"
+      raise e if ! SpreeTaxjar.swallow_errors
+      Rails.logger.error "[Taxjar] Failure: Failed to calculate tax for shipment #{@shipment.id} (#{@shipment.order.number})"
       0
     end
 
     def has_nexus?
       nexus_regions = @client.nexus_regions
-      Rails.logger.debug \
-        order: {id: @order.id, number: @order.number},
-        nexus_regions: nexus_regions,
-        address: {state: tax_address_state_abbr, city: tax_address_city, zip: tax_address_zip}
       if nexus_regions.present?
         nexus_states(nexus_regions).include?(tax_address_state_abbr)
       else
         false
       end
     rescue HTTP::Error
-      Rails.logger.error "Taxjar Failure: Failed to determine nexus for #{@order.number}"
+      Rails.logger.error "[Taxjar] Failure: Failed to determine nexus for #{@order.number}"
       false
     end
 
     def calculate_tax_for_order
-      Rails.logger.debug order: {id: @order.id, number: @order.number}
       if has_nexus?
         api_params = tax_params
-        Rails.logger.debug order: {id: @order.id, number: @order.number}, api_params: api_params
-        api_response = @client.tax_for_order(api_params)
-        Rails.logger.debug order: {id: @order.id, number: @order.number}, api_response: api_response
+        begin
+          api_response = @client.tax_for_order(api_params)
+        rescue Taxjar::Error => e
+          puts "[Taxjar] exception thrown in calculate_tax_for_order - #{e.class.name}"
+          puts "[Taxjar] exception thrown in calculate_tax_for_order - #{e.class.name}"
+          raise e if ! SpreeTaxjar.swallow_errors
+        end
+
+
+        if (SpreeTaxjar.extra_debugging)
+          Rails.logger.debug "[Taxjar] calculate_tax_for_order- for order #{@order.number}  api_params: #{ api_params.to_yaml}"
+          Rails.logger.debug "[Taxjar] calculate_tax_for_order- for order #{@order.number}  api_response: #{ api_response.to_yaml}, breakdown: #{ api_response.breakdown.inspect}"
+        end
         api_response
       end
     rescue HTTP::Error
-      Rails.logger.error "Taxjar Failure: Failed to calcuate tax for #{@order.number}"
+      Rails.logger.error "[Taxjar] Failure in calculate_tax_for_order: Failed to calcuate tax for #{@order.number}"
       nil
     end
 
@@ -101,7 +121,7 @@ module Spree
       end
 
       def tax_address_state_abbr
-        tax_address.state&.abbr
+        tax_address.state.try(:abbr)
       end
 
       def tax_address_city
@@ -117,9 +137,14 @@ module Spree
       end
 
       def tax_params
+        amount = @order.item_total + @order.promo_total + @order.shipment_total
+        # TODO: this is a code smell but fixes a stale object problem
+        if @fresh_lineitem && @fresh_lineitem.changed.include?('promo_total')
+          amount += @fresh_lineitem.promo_total
+        end
         {
-          amount: @order.item_total,
-          shipping: @order.shipment_total,
+          amount: amount.to_f, # Taxjar expects the charges after promotions are applied
+          shipping: @order.shipment_total.to_f,
           to_state: tax_address_state_abbr,
           to_zip: tax_address_zip,
           line_items: taxable_line_items_params
@@ -128,13 +153,23 @@ module Spree
 
       def taxable_line_items_params
         @order.line_items.map do |item|
-          {
-            id: item.id,
-            quantity: item.quantity,
-            unit_price: item.price,
-            discount: item.promo_total,
-            product_tax_code: item.tax_category.try(:tax_code)
-          }
+          if @fresh_lineitem == item
+            {
+              id: @fresh_lineitem.id,
+              quantity: @fresh_lineitem.quantity,
+              unit_price: @fresh_lineitem.price.to_f,
+              discount: @fresh_lineitem.promo_total.abs.to_f, # note: spree keeps promo_total as negative number; Taxjar expects positive number
+              product_tax_code: @fresh_lineitem.tax_category.try(:tax_code)
+            }
+          else
+            {
+              id: item.id,
+              quantity: item.quantity,
+              unit_price: item.price.to_f,
+              discount: item.promo_total.abs.to_f, # note: spree keeps promo_total as negative number; Taxjar expects positive number
+              product_tax_code: item.tax_category.try(:tax_code)
+            }
+          end
         end
       end
 
@@ -175,7 +210,7 @@ module Spree
         address_params.merge({
           transaction_id: @order.number,
           transaction_date: @order.completed_at.as_json,
-          amount: @order.item_total + @order.shipment_total,
+          amount: @order.item_total + @order.promo_total + @order.shipment_total,
           shipping: @order.shipment_total,
           sales_tax: @order.additional_tax_total,
           line_items: line_item_params
@@ -206,11 +241,10 @@ module Spree
             description: "#{item.product.name}: #{item.variant.options_text}",
             unit_price: item.price,
             sales_tax: item.additional_tax_total,
-            discount: item.promo_total,
+            discount: item.promo_total.abs,
             product_tax_code: item.tax_category.try(:tax_code)
           }
         end
       end
-
   end
 end

--- a/lib/spree_taxjar/engine.rb
+++ b/lib/spree_taxjar/engine.rb
@@ -1,4 +1,17 @@
 module SpreeTaxjar
+  class << self
+    mattr_accessor :extra_debugging, :swallow_errors
+    self.extra_debugging = false
+    self.swallow_errors = true # set to fails to raise on taxjar errors
+
+    # add default values of more config vars here
+  end
+
+  # this function maps the vars from your app into your engine
+  def self.setup(&block)
+    yield self
+  end
+
   class Engine < Rails::Engine
     require 'spree/core'
     require 'taxjar'
@@ -18,6 +31,7 @@ module SpreeTaxjar
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end
+
 
     initializer 'spree.register.calculators' do |app|
       app.config.spree.calculators.tax_rates << Spree::Calculator::TaxjarCalculator


### PR DESCRIPTION
… of the cache key; attempting to remove stale data bug (WIP); removing usless debugging statements, adds other debugging statements; adds flag for extra_debugging set as object macro on SpreeTaxjar

removing debugging output
using abs instead of * -1
adds swallow_errors flag in class code for SpreeTaxjar
fixes bug#4 related to the stale-data problem, prefers fresh line item object over stale one from database
fixes line item promotions with fancy stale-object anticipation