### PR TITLE
Fix a broken caching strategy

### DIFF
--- a/app/models/spree/taxjar.rb
+++ b/app/models/spree/taxjar.rb
@@ -59,7 +59,7 @@ module Spree
         api_params = shipment_tax_params
         begin
           api_response = @client.tax_for_order(api_params)
-        rescue Taxjar::Error => e
+        rescue ::Taxjar::Error => e
           puts "[Taxjar] exception thrown calculate_tax_for_shipment - #{e.class.name}"
           puts "[Taxjar] exception thrown calculate_tax_for_shipment- #{e.class.name}"
           raise e if ! SpreeTaxjar.swallow_errors
@@ -91,7 +91,7 @@ module Spree
         api_params = tax_params
         begin
           api_response = @client.tax_for_order(api_params)
-        rescue Taxjar::Error => e
+        rescue ::Taxjar::Error => e
           puts "[Taxjar] exception thrown in calculate_tax_for_order - #{e.class.name}"
           puts "[Taxjar] exception thrown in calculate_tax_for_order - #{e.class.name}"
           raise e if ! SpreeTaxjar.swallow_errors

--- a/solidus_taxjar.gemspec
+++ b/solidus_taxjar.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'solidus'
-  s.add_dependency 'taxjar-ruby', '~> 1.5'
+  s.add_dependency 'taxjar-ruby', '~> 2.2'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
    Fix a broken caching strategy
    
    Previously, only the tax amount for the last line item would be used to
    calculate the taxes for an order.
    
    For instance if I had an item with a tax of 0.5 and an item with a tax of
    1.2. The total tax would have been 2 * 1.2.
    
    Now, we cache the whole TaxJar response and properly pick the correct
    tax amount for each item. The cache key for the TaxJar response should
    make sure that any update to the items, address, or shipping will result
    in a new cache key, and thus an new TaxJar call to fetch up-to-date
    amounts.
